### PR TITLE
Fix syntax error

### DIFF
--- a/lib/capistrano/tasks/newrelic.cap
+++ b/lib/capistrano/tasks/newrelic.cap
@@ -21,7 +21,7 @@ namespace :newrelic do
           :changelog => fetch(:newrelic_changelog),
           :description => fetch(:newrelic_desc),
           :appname => fetch(:newrelic_appname),
-          :user => capture ('git config user.name').strip,
+          :user => capture('git config user.name').strip,
           :license_key => fetch(:newrelic_license_key)
       }
 


### PR DESCRIPTION
The space between the method name and the args was causing a syntax error (on ruby 1.9.3 anyways).
