### PR TITLE
Autoconfiguration based on newrelic.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ Or install it yourself as:
 
         require 'capistrano/newrelic'
 
+License key and application name are retrieved from newrelic.yml.
 
 Configurable options, shown here with defaults:
 
-      set :newrelic_env, fetch(:rack_env, fetch(:rails_env, 'production'))
-      set :newrelic_appname, fetch(:application)
-
-Mandatory options:
-
-      :newrelic_license_key
+      # New Relic environment to deploy to. Sets config based on section of newrelic.yml
+      set :newrelic_env, fetch(:stage, fetch(:rack_env, fetch(:rails_env, 'production')))
+      # Deployment changelog
+      set :newrelic_changelog, ""
+      # Deployment description
+      set :newrelic_desc, ""
 
 ## Contributing
 

--- a/capistrano-newrelic.gemspec
+++ b/capistrano-newrelic.gemspec
@@ -6,8 +6,8 @@ require 'capistrano/newrelic/version'
 Gem::Specification.new do |spec|
   spec.name          = 'capistrano-newrelic'
   spec.version       = Capistrano::NewRelic::VERSION
-  spec.authors       = ['Abdelkader Boudih', 'Jay Chung']
-  spec.email         = ['terminale@gmail.com', 'woosubc@gmail.com']
+  spec.authors       = ['Abdelkader Boudih', 'Jay Chung', 'James Kahn']
+  spec.email         = ['terminale@gmail.com', 'woosubc@gmail.com', 'james@liet.net']
   spec.description   = %q{New Relic integration for Capistrano 3}
   spec.summary       = %q{New Relic integration for Capistrano}
   spec.homepage      = 'https://github.com/seuros/capistrano-newrelic'

--- a/lib/capistrano/newrelic/version.rb
+++ b/lib/capistrano/newrelic/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module NewRelic
-    VERSION = '0.0.3'
+    VERSION = '0.0.4'
   end
 end

--- a/lib/capistrano/tasks/newrelic.cap
+++ b/lib/capistrano/tasks/newrelic.cap
@@ -4,8 +4,7 @@ end
 
 namespace :load do
   task :defaults do
-    set :newrelic_env, fetch(:rack_env, fetch(:rails_env, 'production'))
-    set :newrelic_appname, fetch(:application)
+    set :newrelic_env, fetch(:stage, fetch(:rack_env, fetch(:rails_env, 'production')))
   end
 end
 
@@ -20,11 +19,8 @@ namespace :newrelic do
           :revision => release_timestamp.strip,
           :changelog => fetch(:newrelic_changelog),
           :description => fetch(:newrelic_desc),
-          :appname => fetch(:newrelic_appname),
           :user => capture('git config user.name').strip,
-          :license_key => fetch(:newrelic_license_key)
       }
-
 
       debug "Uploading deployment to New Relic"
       deployment = NewRelic::Cli::Deployments.new deploy_options


### PR DESCRIPTION
Make it use app name and license key from newrelic.yml - they'll be there anyway. No config required, just include.
Use stage as default environment. Was previously using local env, which doesn't make sense in a multistage deployment.
Bump version.
