### PR TITLE
Improved log/revision capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,47 +16,68 @@ Or install it yourself as:
     $ gem install capistrano-newrelic
 
 ## Usage
-   # Capfile
 
-        require 'capistrano/newrelic'
+#### In Capfile
 
-License key and application name are retrieved from newrelic.yml.
+    require 'capistrano/newrelic'
+
+#### In stage files
+
+In your Capfile, or stage configuration files for multi-stage configuration add:
+
+```ruby
+    before 'deploy:finished', 'newrelic:notice_deployment'
+```
+License key and application name are retrieved from `config/newrelic.yml` based
+on the environment setting (defaults to value of `rails_env`,
+`rack_env` and can be overridden by setting `newrelic_env`).
+
+#### In deploy.rb
 
 Configurable options, shown here with defaults:
 
+```ruby
       # New Relic environment to deploy to. Sets config based on section of newrelic.yml
       set :newrelic_env, fetch(:stage, fetch(:rack_env, fetch(:rails_env, 'production')))
-      # Deployment changelog
-      set :newrelic_changelog, ""
+
+      # Deployment changelog defaults to the git changelog, if using git
+      set :newrelic_changelog, "<git changelog if available>"
+
       # Deployment description
       set :newrelic_desc, ""
+
       # Deploy user if set will be used instead of the VCS user.
       set :newrelic_deploy_user
+```      
 
 ## Changelog
+
+0.0.9:
+   * Added changelog capture for git
+   * Populate revision with `current_revision` from scm if available;
+     i.e., the git SHA
+
 0.0.8:
- - Hook was removed, please set it in your deploy.rb or deploy/'stage'.rb
+   * Hook was removed, please set it in your deploy.rb or deploy/'stage'.rb
+   ```ruby
+   before 'deploy:finished', 'newrelic:notice_deployment'
+   ```
 
-
-        namespace :deploy do
-          before :finished, 'newrelic:notice_deployment'
-        end
-
- - Revision can be set with :
-
-
-        set :newrelic_revision, "Your text here"
-
-    or
-
-        $ NEWRELIC_REVISION='Your text here' bundle exe cap ....
-
+   * Revision can be set with :
+   ```ruby
+   set :newrelic_revision, "Your text here"
+   ```
+   or
+   ```ruby
+   $ NEWRELIC_REVISION='Your text here' bundle exe cap ....
+   ```
 
 ## Contributors
 
 - [Bryan Ricker] (https://github.com/bricker)
 - [James Kahn] (https://github.com/jisk)
 - [Wojciech Wnętrzak] (https://github.com/morgoth)
+- [Bill Kayser (New Relic)] (https://github.com/bkayser)
 
 ## Contributing
 

--- a/lib/capistrano/newrelic.rb
+++ b/lib/capistrano/newrelic.rb
@@ -1,3 +1,1 @@
-require 'newrelic_rpm'
-require 'new_relic/cli/command'
-load File.expand_path('../tasks/newrelic.cap', __FILE__)
+load File.expand_path("../tasks/newrelic.rake", __FILE__)

--- a/lib/capistrano/newrelic/version.rb
+++ b/lib/capistrano/newrelic/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module NewRelic
-    VERSION = '0.0.8'
+    VERSION = '0.0.9'
   end
 end


### PR DESCRIPTION
I made some changes to improve the info sent to New Relic.
* Capture the git SHA or whatever version is defined by the configured SCM
* Send the changelog since the last deploy if git is available
* Default the user to `$USER` if not otherwise discovered

The changelog capture is particularly helpful and will show up on the deploy page looking like this:

![deployment_at_yesterday__18_04_-_new_relic](https://cloud.githubusercontent.com/assets/27471/6510488/38b39d16-c31b-11e4-873a-7927ac49f27a.png)

Thanks for writing this plugin!
