### PR TITLE
Use git --no-pager option when printing the commits being deployed

### DIFF
--- a/lib/capistrano/tasks/newrelic.rake
+++ b/lib/capistrano/tasks/newrelic.rake
@@ -9,7 +9,7 @@ namespace :newrelic do
     if changelog.nil? && fetch(:scm) == :git
       on primary(:app) do
         within repo_path do
-          changelog = capture(:git, "log --no-color --pretty=format:'* %an: %s' --abbrev-commit --no-merges #{fetch(:previous_revision)[/^.*$/]}..#{fetch(:current_revision)}")
+          changelog = capture(:git, "--no-pager log --no-color --pretty=format:'* %an: %s' --abbrev-commit --no-merges #{fetch(:previous_revision)[/^.*$/]}..#{fetch(:current_revision)}")
         end
       end
     end


### PR DESCRIPTION
Use git --no-pager option when printing the commits being deployed. This prevents git from displaying the commits using less which hangs up a deploy. Specifically, when using airbrush the deploy will hang when the `git log ...` command is run in this gem. 