### PR TITLE
Fix error deriving changelog when previous_revision is nil

### DIFF
--- a/lib/capistrano/tasks/newrelic.rake
+++ b/lib/capistrano/tasks/newrelic.rake
@@ -6,7 +6,7 @@ namespace :newrelic do
   task :notice_deployment do
     set :newrelic_appname, fetch(:application)
     changelog = fetch :newrelic_changelog
-    if changelog.nil? && fetch(:scm) == :git
+    if changelog.nil? && fetch(:scm) == :git && !fetch(:previous_revision).nil?
       on primary(:app) do
         within repo_path do
           changelog = capture(:git, "--no-pager log --no-color --pretty=format:'* %an: %s' --abbrev-commit --no-merges #{fetch(:previous_revision)[/^.*$/]}..#{fetch(:current_revision)}")
@@ -14,14 +14,16 @@ namespace :newrelic do
       end
     end
 
+
     run_locally do
       deploy_options = {
           :environment => fetch(:newrelic_env, fetch(:stage, fetch(:rack_env, fetch(:rails_env, fetch(:stage))))),
           :revision => ENV['NEWRELIC_REVISION'] || fetch(:newrelic_revision, fetch(:current_revision, release_timestamp.strip)),
-          :changelog => changelog,
           :description => fetch(:newrelic_desc),
           :user => fetch(:newrelic_deploy_user)
       }
+
+      deploy_options[:changelog] = changelog unless changelog.nil?
 
       if deploy_options[:user].nil?
         case fetch(:scm)


### PR DESCRIPTION
For the first deploy of an application, previous_revision is nil and
thus `fetch(:previous_revision)[/^.*$/]` throws an exception when trying
to run `git log`.

Just omit the changelog on the first deploy of an app since that info
isn't particularly interesting on initial deployment.

For reference, previous_revision is set in
https://github.com/capistrano/capistrano/blob/848301718570b168ef491974e3ba5b5055d63648/lib/capistrano/tasks/deploy.rake#L231-L233