### PR TITLE
jr-nr-appname

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Configurable options, shown here with defaults:
 
 ```ruby
       # New Relic Application Name to deploy to.  Default to :application if no value set
-      set :nr_app_name, ""
+      set :newrelic_appname, ""
 
       # New Relic environment to deploy to. Sets config based on section of newrelic.yml
       set :newrelic_env, fetch(:stage, fetch(:rack_env, fetch(:rails_env, 'production')))

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ on the environment setting (defaults to value of `rails_env`,
 Configurable options, shown here with defaults:
 
 ```ruby
+      # New Relic Application Name to deploy to.  Default to :application if no value set
+      set :nr_app_name, ""
+
       # New Relic environment to deploy to. Sets config based on section of newrelic.yml
       set :newrelic_env, fetch(:stage, fetch(:rack_env, fetch(:rails_env, 'production')))
 

--- a/lib/capistrano/newrelic/version.rb
+++ b/lib/capistrano/newrelic/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module NewRelic
-    VERSION = '0.10.1'
+    VERSION = '0.10.2'
   end
 end

--- a/lib/capistrano/tasks/newrelic.rake
+++ b/lib/capistrano/tasks/newrelic.rake
@@ -20,7 +20,7 @@ namespace :newrelic do
           :revision => ENV['NEWRELIC_REVISION'] || fetch(:newrelic_revision, fetch(:current_revision, release_timestamp.strip)),
           :description => fetch(:newrelic_desc),
           :user => fetch(:newrelic_deploy_user),
-          :appname => fetch(:newrelic_appname,fetch(:application))
+          :appname => fetch(:newrelic_appname,fetch(:application)),
           :license_key => fetch(:newrelic_key)
       }
 

--- a/lib/capistrano/tasks/newrelic.rake
+++ b/lib/capistrano/tasks/newrelic.rake
@@ -20,7 +20,7 @@ namespace :newrelic do
           :revision => ENV['NEWRELIC_REVISION'] || fetch(:newrelic_revision, fetch(:current_revision, release_timestamp.strip)),
           :description => fetch(:newrelic_desc),
           :user => fetch(:newrelic_deploy_user),
-          :appname => fetch(:newrelic_appname) || fetch(:application),
+          :appname => fetch(:newrelic_appname,fetch(:application))
           :license_key => fetch(:newrelic_key)
       }
 

--- a/lib/capistrano/tasks/newrelic.rake
+++ b/lib/capistrano/tasks/newrelic.rake
@@ -4,7 +4,6 @@ require 'new_relic/cli/command'
 namespace :newrelic do
   desc "Record a deployment in New Relic (newrelic.com)"
   task :notice_deployment do
-    set :newrelic_appname, fetch(:nr_app_name) || fetch(:application)
     changelog = fetch :newrelic_changelog
     if changelog.nil? && fetch(:scm) == :git && !fetch(:previous_revision).nil?
       on primary(:app) do
@@ -20,7 +19,9 @@ namespace :newrelic do
           :environment => fetch(:newrelic_env, fetch(:stage, fetch(:rack_env, fetch(:rails_env, fetch(:stage))))),
           :revision => ENV['NEWRELIC_REVISION'] || fetch(:newrelic_revision, fetch(:current_revision, release_timestamp.strip)),
           :description => fetch(:newrelic_desc),
-          :user => fetch(:newrelic_deploy_user)
+          :user => fetch(:newrelic_deploy_user),
+          :appname => fetch(:newrelic_appname) || fetch(:application),
+          :license_key => fetch(:newrelic_key)
       }
 
       deploy_options[:changelog] = changelog unless changelog.nil?

--- a/lib/capistrano/tasks/newrelic.rake
+++ b/lib/capistrano/tasks/newrelic.rake
@@ -4,7 +4,7 @@ require 'new_relic/cli/command'
 namespace :newrelic do
   desc "Record a deployment in New Relic (newrelic.com)"
   task :notice_deployment do
-    set :newrelic_appname, fetch(:application)
+    set :newrelic_appname, fetch(:nr_app_name) || fetch(:application)
     changelog = fetch :newrelic_changelog
     if changelog.nil? && fetch(:scm) == :git && !fetch(:previous_revision).nil?
       on primary(:app) do


### PR DESCRIPTION
Adding appname and license key as options, helpful when using multiconfig with cap for multiple projects.